### PR TITLE
Feature: add a simple CLI tool to generate config file for CoLLiE

### DIFF
--- a/collie/commands/README.md
+++ b/collie/commands/README.md
@@ -1,0 +1,19 @@
+This folder implements the command-line tools for collie.
+
+# Commands
+
+## collie config
+
+### collie config [--config_file <PATH>]
+
+This command gives an interactive prompt to generate a configuration file for collie.
+
+If `--config_file` is specified, the configuration file will be generated at the given path. Otherwise, the configuration file will be generated at `./collie_default.yml`.
+
+### collie config default [--config_file <PATH>]
+
+> To be implemented.
+
+This command generate the default configuration file for collie.
+
+If `--config_file` is specified, the configuration file will be generated at the given path. Otherwise, the configuration file will be generated at `./collie_default.yml`.

--- a/collie/commands/collie_cli.py
+++ b/collie/commands/collie_cli.py
@@ -1,0 +1,27 @@
+from argparse import ArgumentParser
+
+from .config import config_command_parser
+
+
+def main():
+    # TODO: add help information
+    parser = ArgumentParser(
+        "Collie CLI",
+        usage="collie <command> [<args>]",
+        allow_abbrev=False,
+    )
+    subparsers = parser.add_subparsers()
+
+    config_command_parser(subparsers=subparsers)
+
+    args = parser.parse_args()
+
+    if not hasattr(args, "entrypoint"):
+        parser.print_help()
+        exit(1)
+
+    args.entrypoint(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/collie/commands/config.py
+++ b/collie/commands/config.py
@@ -1,0 +1,118 @@
+import argparse
+
+import yaml
+from bullet import Bullet, Input, Numbers, VerticalPrompt, colors, styles
+
+
+def config_command_parser(subparsers=None):
+    if subparsers is not None:
+        parser = subparsers.add_parser("config")
+    else:
+        parser = argparse.ArgumentParser("Accelerate config command")
+
+    parser.add_argument(
+        "--config_file",
+        default="./collie_default.yml",
+        help="If --config_file is specified, the configuration file will be generated at the given path. Otherwise, the configuration file will be generated at ./collie_default.yml.",
+        type=str,
+    )
+
+    if subparsers is not None:
+        parser.set_defaults(entrypoint=config_command_entry)
+    return parser
+
+
+def config_command_entry(args):
+    prompt_argname_map = {
+        "随机数种子": "seed",
+        "流水线并行的大小": "pp_size",
+        "张量并行大小": "tp_size",
+        "数据并行大小": "dp_size",
+        "流水线的切分策略": "pp_partition_method",
+        "训练时的迭代次数": "train_epochs",
+        "训练的一个 epoch 中，每隔多少 step 进行一次验证": "eval_per_n_steps",
+        "训练过程中每隔多少次迭代进行一次验证": "eval_per_n_epochs",
+        "每个 gpu 上的 batch_size": "train_micro_batch_size",
+        "梯度累积的 step 数目": "gradient_accumulation_steps",
+        "验证时的 batch 大小": "eval_batch_size",
+        "你希望使用梯度检查点吗？": "checkpointing",
+        "你希望使用 FlashAttention 吗？": "use_flash",
+        "Dropout 的概率": "dropout",
+        "初始化方法": "initization_method",
+        "DeepSpeed 配置": "ds_config",
+    }
+
+    word_color = colors.foreground["cyan"]
+
+    config_command_cli = VerticalPrompt(
+        [
+            Input("随机数种子", default="42", word_color=word_color),
+            Input("流水线并行的大小", default="1", word_color=word_color),
+            Input("张量并行大小", default="1", word_color=word_color),
+            Input("数据并行大小", default="1", word_color=word_color),
+            Bullet(
+                "流水线的切分策略",
+                choices=["parameters", "uniform", "type:[regex]"],
+                bullet=" >",
+                margin=2,
+                word_color=word_color,
+            ),
+            Input("训练时的迭代次数", default="100", word_color=word_color),
+            Input(
+                "训练的一个 epoch 中，每隔多少 step 进行一次验证",
+                default="0",
+                word_color=word_color,
+            ),
+            Input("训练过程中每隔多少次迭代进行一次验证", default="0", word_color=word_color),
+            Input("每个 gpu 上的 batch_size", default="1", word_color=word_color),
+            Input("梯度累积的 step 数目", default="1", word_color=word_color),
+            Input("验证时的 batch 大小", default="1", word_color=word_color),
+            Bullet(
+                "你希望使用梯度检查点吗？",
+                choices=[
+                    "Yes",
+                    "No",
+                ],
+                bullet=" >",
+                word_color=word_color,
+            ),
+            Bullet(
+                "你希望使用 FlashAttention 吗？",
+                choices=[
+                    "Yes",
+                    "No",
+                ],
+                bullet=" >",
+                word_color=word_color,
+            ),
+            Input("Dropout 的概率", default="0.0", word_color=word_color),
+            Bullet(
+                "初始化方法",
+                choices=[
+                    "normal",
+                    "xavier_normal",
+                    "xavier_uniform",
+                    "kaiming_normal",
+                    "kaiming_uniform",
+                    "orthogonal",
+                    "sparse",
+                    "eye",
+                    "dirac",
+                ],
+                bullet=" >",
+                word_color=word_color,
+            ),
+            Input("DeepSpeed 配置", default="ds_config.yml", word_color=word_color),
+        ]
+    )
+    result = config_command_cli.launch()
+    config = {
+        prompt_argname_map[k]: (
+            v if v not in ("Yes", "No") else (True if v == "Yes" else False)
+        )
+        for k, v in result
+    }
+
+    with open(args.config_file, "w") as f:
+        yaml.dump(config, f, Dumper=yaml.SafeDumper)
+        print(f"🎉 配置文件已保存至 {args.config_file}")

--- a/collie/commands/config.py
+++ b/collie/commands/config.py
@@ -22,41 +22,43 @@ def config_command_parser(subparsers=None):
     return parser
 
 
-def config_command_entry(args):
-    prompt_argname_map = {
-        "随机数种子": "seed",
-        "流水线并行的大小": "pp_size",
-        "张量并行大小": "tp_size",
-        "数据并行大小": "dp_size",
-        "流水线的切分策略": "pp_partition_method",
-        "训练时的迭代次数": "train_epochs",
-        "训练的一个 epoch 中，每隔多少 step 进行一次验证": "eval_per_n_steps",
-        "训练过程中每隔多少次迭代进行一次验证": "eval_per_n_epochs",
-        "每个 gpu 上的 batch_size": "train_micro_batch_size",
-        "梯度累积的 step 数目": "gradient_accumulation_steps",
-        "验证时的 batch 大小": "eval_batch_size",
-        "你希望使用梯度检查点吗？": "checkpointing",
-        "你希望使用 FlashAttention 吗？": "use_flash",
-        "Dropout 的概率": "dropout",
-        "初始化方法": "initization_method",
-        "DeepSpeed 配置": "ds_config",
-    }
+_prompt_argname_map = {
+    "随机数种子": "seed",
+    "流水线并行的大小": "pp_size",
+    "张量并行大小": "tp_size",
+    "数据并行大小": "dp_size",
+    "流水线的切分策略": "pp_partition_method",
+    "训练时的迭代次数": "train_epochs",
+    "训练的一个 epoch 中，每隔多少 step 进行一次验证": "eval_per_n_steps",
+    "训练过程中每隔多少次迭代进行一次验证": "eval_per_n_epochs",
+    "每个 gpu 上的 batch_size": "train_micro_batch_size",
+    "梯度累积的 step 数目": "gradient_accumulation_steps",
+    "验证时的 batch 大小": "eval_batch_size",
+    "你希望使用梯度检查点吗？": "checkpointing",
+    "你希望使用 FlashAttention 吗？": "use_flash",
+    "Dropout 的概率": "dropout",
+    "初始化方法": "initization_method",
+    "DeepSpeed 配置": "ds_config",
+}
 
+
+def _parse(v):
+    if v.isdigit():
+        return int(v)
+    elif v.replace(".", "", 1).isdigit():
+        return float(v)
+    elif v in ["Yes", "No"]:
+        return v == "Yes"
+    else:
+        return v
+
+
+def config_command_entry(args):
     word_color = colors.foreground["cyan"]
 
     config_command_cli = VerticalPrompt(
         [
             Input("随机数种子", default="42", word_color=word_color),
-            Input("流水线并行的大小", default="1", word_color=word_color),
-            Input("张量并行大小", default="1", word_color=word_color),
-            Input("数据并行大小", default="1", word_color=word_color),
-            Bullet(
-                "流水线的切分策略",
-                choices=["parameters", "uniform", "type:[regex]"],
-                bullet=" >",
-                margin=2,
-                word_color=word_color,
-            ),
             Input("训练时的迭代次数", default="100", word_color=word_color),
             Input(
                 "训练的一个 epoch 中，每隔多少 step 进行一次验证",
@@ -103,15 +105,35 @@ def config_command_entry(args):
                 word_color=word_color,
             ),
             Input("DeepSpeed 配置", default="ds_config.yml", word_color=word_color),
+            Input("流水线并行的大小", default="1", word_color=word_color),
+            Input("张量并行大小", default="1", word_color=word_color),
+            Input("数据并行大小", default="1", word_color=word_color),
+            Bullet(
+                "流水线的切分策略",
+                choices=["parameters", "uniform", "type:[regex]"],
+                bullet=" >",
+                margin=2,
+                word_color=word_color,
+            ),
         ]
     )
+
+    regx_cli = VerticalPrompt(
+        [
+            Input(
+                "你选择的流水线切分策略为 type:[regex]，请在此输入正则表达式：",
+                default="",
+                word_color=word_color,
+            )
+        ],
+    )
+
     result = config_command_cli.launch()
-    config = {
-        prompt_argname_map[k]: (
-            v if v not in ("Yes", "No") else (True if v == "Yes" else False)
-        )
-        for k, v in result
-    }
+    config = {_prompt_argname_map[k]: _parse(v) for k, v in result}
+
+    if config["pp_partition_method"] == "type:[regex]":
+        regx_result = regx_cli.launch()
+        config["pp_partition_method"] = regx_result[0][1]
 
     with open(args.config_file, "w") as f:
         yaml.dump(config, f, Dumper=yaml.SafeDumper)

--- a/collie/commands/config.py
+++ b/collie/commands/config.py
@@ -1,7 +1,7 @@
 import argparse
 
 import yaml
-from bullet import Bullet, Input, Numbers, VerticalPrompt, colors, styles
+from bullet import Bullet, Input, VerticalPrompt, colors
 
 
 def config_command_parser(subparsers=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ google
 peft
 wandb
 pandas
+bullet

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,20 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
-with open('requirements.txt', encoding='utf-8') as f:
+with open("requirements.txt", encoding="utf-8") as f:
     reqs = f.read()
-    
-setup(name='collie',
-      version='1.0.1',
-      description="CoLLiE: Collaborative Tuning of Large Language Models in an Efficient Way",
-      author="OpenLMLab",
-      author_email="yanhang@pjlab.org.cn",
-      packages=find_packages(),
-      install_requires=reqs.splitlines(),
-      python_requires='>=3.8')
+
+setup(
+    name="collie",
+    version="1.0.1",
+    description="CoLLiE: Collaborative Tuning of Large Language Models in an Efficient Way",
+    author="OpenLMLab",
+    author_email="yanhang@pjlab.org.cn",
+    packages=find_packages(),
+    install_requires=reqs.splitlines(),
+    python_requires=">=3.8",
+    entry_points={
+        "console_scripts": [
+            "collie = collie.commands.collie_cli:main",
+        ],
+    },
+)


### PR DESCRIPTION
This pull request implemented a simple CLI tool to generate config file for CoLLiE. User can run `collie config` to get an interactive instruction. The detailed introduction of the command can be found at `/collie/commands/README.md`

![image](https://github.com/OpenLMLab/collie/assets/54014142/49680e9b-4d58-4496-862a-5d63f58432ab)

There is a known issues to be discussed:

```
[2023-06-24 16:50:36,386] [INFO] [real_accelerator.py:110:get_accelerator] Setting ds_accelerator to cuda (auto detect)
```

This line shows every time `collie config` is executed. Can anyone reproduce it or is it expected?