### PR TITLE
重构ChatGLM2并增加对应测试用例

### DIFF
--- a/collie/metrics/accuracy.py
+++ b/collie/metrics/accuracy.py
@@ -105,4 +105,4 @@ class AccuracyMetric(BaseMetric):
             self.total += torch.sum(masks).item()
         else:
             self.correct += torch.sum(torch.eq(pred, target)).item()
-            self.total += np.prod(list(pred.size()))
+            self.total += np.prod(list(pred.size())).item()

--- a/collie/models/chatglm2/model.py
+++ b/collie/models/chatglm2/model.py
@@ -454,7 +454,6 @@ class ChatGLM2Layer(nn.Module):
 
         # Layer norm at the beginning of the transformer layer.
         layernorm_output = self.input_layernorm(hidden_states)
-        # import pdb;pdb.set_trace()
         # Attention heads [sq, b, h] --> [sq, b, (np * 3 * hn)]
         if self.multi_query_attention:
             query_layer = self.attention["query_layer"](layernorm_output)

--- a/tests/models/chatglm2/test_finetune_glm2_for_cls.py
+++ b/tests/models/chatglm2/test_finetune_glm2_for_cls.py
@@ -1,0 +1,96 @@
+import sys
+sys.path.append("../../../")
+from collie import Trainer, EvaluatorForPerplexity, ChatGLM2ForCausalLM, CollieConfig, PPLMetric, AccuracyMetric, DecodeMetric, CollieDatasetForTraining, CollieDatasetForClassification, \
+    LossMonitor, TGSMonitor, MemoryMonitor, EvalMonitor, GradioProvider, EvaluatorForClassfication, LRMonitor
+from transformers import AutoTokenizer
+from datasets import load_dataset
+import torch
+
+config = CollieConfig.from_pretrained("THUDM/chatglm2-6b", trust_remote_code=True)
+config.pp_size = 8
+config.train_micro_batch_size = 4
+config.eval_batch_size = 2
+config.gradient_accumulation_steps = 2
+config.eval_per_n_steps = 1000
+config.train_epochs = 1
+# config.checkpointing = False
+config.ds_config = {
+    "fp16": {
+        "enabled": True
+    },
+    "zero_optimization": {
+        "stage": 1,
+    }
+}
+config.seed = 1024
+model = ChatGLM2ForCausalLM.from_pretrained("THUDM/chatglm2-6b", config=config)
+# model = LlamaForCausalLM.from_config(config)
+optimizer = torch.optim.AdamW(model.parameters(), lr=2e-5)
+lr_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=1000)
+### Prepare training dataset
+train_dataset = [
+    {
+        "input": f"Comment: {sample['text']}. The sentiment of this comment is: ",
+        "output": "positive." if sample["label"] else "negative."
+    } for sample in load_dataset("imdb", split="train")
+]
+### Prepare perplexity evaluation dataset
+ratio = 0.01
+eval_dataset_ppl, train_dataset = train_dataset[:int(len(train_dataset) * ratio)], train_dataset[int(len(train_dataset) * ratio):]
+### Prepare classification evaluation dataset
+eval_dataset_cls = [
+    {
+        "input": f"Comment: {sample['text']}. The sentiment of this comment is: ",
+        "output": ["negative.", "positive."],
+        "target": sample["label"] 
+    } for sample in load_dataset("imdb", split="test")
+][:1000]
+### Convert to CoLLie Dataset
+traine_dataset = CollieDatasetForTraining(train_dataset, 
+                                          tokenizer=AutoTokenizer.from_pretrained("THUDM/chatglm2-6b", trust_remote_code=True, add_eos_token=True))
+eval_dataset_ppl = CollieDatasetForTraining(eval_dataset_ppl, 
+                                            tokenizer=AutoTokenizer.from_pretrained("THUDM/chatglm2-6b", trust_remote_code=True, add_eos_token=True))
+eval_dataset_cls = CollieDatasetForClassification(eval_dataset_cls, 
+                                              tokenizer=AutoTokenizer.from_pretrained("THUDM/chatglm2-6b", trust_remote_code=True, add_eos_token=True))
+### Prepare Evaluator
+evaluator_ppl = EvaluatorForPerplexity(
+    model=model,
+    config=config,
+    dataset=eval_dataset_ppl,
+    monitors=[
+        EvalMonitor(config)
+    ],
+    metrics={
+        "ppl": PPLMetric(gather_result=True)
+    },
+)
+evaluator_cls = EvaluatorForClassfication(
+    model=model,
+    config=config,
+    dataset=eval_dataset_cls,
+    monitors=[
+        EvalMonitor(config)
+    ],
+    metrics={
+        "acc": AccuracyMetric(gather_result=True)
+    },
+)
+### Prepare Trainer
+trainer = Trainer(
+    model=model,
+    lr_scheduler=lr_scheduler,
+    config=config,
+    optimizer=optimizer,
+    train_dataset=traine_dataset,
+    monitors=[
+        LossMonitor(config),
+        TGSMonitor(config),
+        MemoryMonitor(config),
+        LRMonitor(config)
+    ],
+    evaluators=evaluator_cls
+    # evaluators=[evaluator_ppl, evaluator_cls]
+)
+trainer.train()
+# trainer.save_checkpoint(path="/mnt/petrelfs/zhangshuo/model/test_save_checkpoint", mode="model")
+

--- a/tests/models/chatglm2/test_finetune_glm2_for_cls_3d.py
+++ b/tests/models/chatglm2/test_finetune_glm2_for_cls_3d.py
@@ -1,0 +1,100 @@
+import sys
+sys.path.append("../../../")
+from collie import Trainer, EvaluatorForPerplexity, ChatGLM2ForCausalLM, CollieConfig, PPLMetric, AccuracyMetric, DecodeMetric, CollieDatasetForTraining, CollieDatasetForClassification, \
+    LossMonitor, TGSMonitor, MemoryMonitor, EvalMonitor, GradioProvider, EvaluatorForClassfication, LRMonitor, setup_distribution
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from datasets import load_dataset
+import torch
+
+config = CollieConfig.from_pretrained("THUDM/chatglm2-6b", trust_remote_code=True)
+config.dp_size = 4
+config.tp_size = 2
+config.train_micro_batch_size = 4
+config.eval_batch_size = 4
+config.gradient_accumulation_steps = 1
+config.eval_per_n_steps = 300
+config.train_epochs = 1
+# config.checkpointing = False
+config.ds_config = {
+    "fp16": {
+        "enabled": True
+    },
+    "zero_optimization": {
+        "stage": 2,
+    }
+}
+config.seed = 1024
+setup_distribution(config)
+model = ChatGLM2ForCausalLM.from_pretrained("THUDM/chatglm2-6b", config=config)
+# model = LlamaForCausalLM.from_config(config)
+# model = AutoModelForCausalLM.from_pretrained("THUDM/chatglm2-6b", trust_remote_code=True, torch_dtype=torch.float16)
+# model.gradient_checkpointing_enable()
+optimizer = torch.optim.AdamW(model.parameters(), lr=2e-5)
+lr_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=1000)
+### Prepare training dataset
+train_dataset = [
+    {
+        "input": f"Comment: {sample['text']}. The sentiment of this comment is: ",
+        "output": "positive." if sample["label"] else "negative."
+    } for sample in load_dataset("imdb", split="train")
+]
+### Prepare perplexity evaluation dataset
+ratio = 0.01
+eval_dataset_ppl, train_dataset = train_dataset[:int(len(train_dataset) * ratio)], train_dataset[int(len(train_dataset) * ratio):]
+### Prepare classification evaluation dataset
+eval_dataset_cls = [
+    {
+        "input": f"Comment: {sample['text']}. The sentiment of this comment is: ",
+        "output": ["negative.", "positive."],
+        "target": sample["label"] 
+    } for sample in load_dataset("imdb", split="test")
+][:1000]
+### Convert to CoLLie Dataset
+traine_dataset = CollieDatasetForTraining(train_dataset, 
+                                          tokenizer=AutoTokenizer.from_pretrained("THUDM/chatglm2-6b", trust_remote_code=True, add_eos_token=True))
+eval_dataset_ppl = CollieDatasetForTraining(eval_dataset_ppl, 
+                                            tokenizer=AutoTokenizer.from_pretrained("THUDM/chatglm2-6b", trust_remote_code=True, add_eos_token=True))
+eval_dataset_cls = CollieDatasetForClassification(eval_dataset_cls, 
+                                              tokenizer=AutoTokenizer.from_pretrained("THUDM/chatglm2-6b", trust_remote_code=True, add_eos_token=True))
+### Prepare Evaluator
+evaluator_ppl = EvaluatorForPerplexity(
+    model=model,
+    config=config,
+    dataset=eval_dataset_ppl,
+    monitors=[
+        EvalMonitor(config)
+    ],
+    metrics={
+        "ppl": PPLMetric(gather_result=True)
+    },
+)
+evaluator_cls = EvaluatorForClassfication(
+    model=model,
+    config=config,
+    dataset=eval_dataset_cls,
+    monitors=[
+        EvalMonitor(config)
+    ],
+    metrics={
+        "acc": AccuracyMetric(gather_result=True)
+    },
+)
+### Prepare Trainer
+trainer = Trainer(
+    model=model,
+    lr_scheduler=lr_scheduler,
+    config=config,
+    optimizer=optimizer,
+    train_dataset=traine_dataset,
+    monitors=[
+        LossMonitor(config),
+        TGSMonitor(config),
+        MemoryMonitor(config),
+        LRMonitor(config)
+    ],
+    evaluators=evaluator_cls
+    # evaluators=[evaluator_ppl, evaluator_cls]
+)
+trainer.train()
+# trainer.save_checkpoint(path="/mnt/petrelfs/zhangshuo/model/test_save_checkpoint", mode="model")
+

--- a/tests/models/chatglm2/test_finetune_glm2_for_cls_dp.py
+++ b/tests/models/chatglm2/test_finetune_glm2_for_cls_dp.py
@@ -1,0 +1,99 @@
+import sys
+sys.path.append("../../../")
+from collie import Trainer, EvaluatorForPerplexity, ChatGLM2ForCausalLM, CollieConfig, PPLMetric, AccuracyMetric, DecodeMetric, CollieDatasetForTraining, CollieDatasetForClassification, \
+    LossMonitor, TGSMonitor, MemoryMonitor, EvalMonitor, GradioProvider, EvaluatorForClassfication, LRMonitor, setup_distribution
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from datasets import load_dataset
+import torch
+
+config = CollieConfig.from_pretrained("THUDM/chatglm2-6b", trust_remote_code=True)
+config.dp_size = 8
+config.train_micro_batch_size = 4
+config.eval_batch_size = 4
+config.gradient_accumulation_steps = 1
+config.eval_per_n_steps = 300
+config.train_epochs = 1
+# config.checkpointing = False
+config.ds_config = {
+    "fp16": {
+        "enabled": True
+    },
+    "zero_optimization": {
+        "stage": 2,
+    }
+}
+config.seed = 1024
+setup_distribution(config)
+model = ChatGLM2ForCausalLM.from_pretrained("THUDM/chatglm2-6b", config=config)
+# model = LlamaForCausalLM.from_config(config)
+# model = AutoModelForCausalLM.from_pretrained("THUDM/chatglm2-6b", trust_remote_code=True, torch_dtype=torch.float16)
+# model.gradient_checkpointing_enable()
+optimizer = torch.optim.AdamW(model.parameters(), lr=2e-5)
+lr_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=1000)
+### Prepare training dataset
+train_dataset = [
+    {
+        "input": f"Comment: {sample['text']}. The sentiment of this comment is: ",
+        "output": "positive." if sample["label"] else "negative."
+    } for sample in load_dataset("imdb", split="train")
+]
+### Prepare perplexity evaluation dataset
+ratio = 0.01
+eval_dataset_ppl, train_dataset = train_dataset[:int(len(train_dataset) * ratio)], train_dataset[int(len(train_dataset) * ratio):]
+### Prepare classification evaluation dataset
+eval_dataset_cls = [
+    {
+        "input": f"Comment: {sample['text']}. The sentiment of this comment is: ",
+        "output": ["negative.", "positive."],
+        "target": sample["label"] 
+    } for sample in load_dataset("imdb", split="test")
+][:1000]
+### Convert to CoLLie Dataset
+traine_dataset = CollieDatasetForTraining(train_dataset, 
+                                          tokenizer=AutoTokenizer.from_pretrained("THUDM/chatglm2-6b", trust_remote_code=True, add_eos_token=True))
+eval_dataset_ppl = CollieDatasetForTraining(eval_dataset_ppl, 
+                                            tokenizer=AutoTokenizer.from_pretrained("THUDM/chatglm2-6b", trust_remote_code=True, add_eos_token=True))
+eval_dataset_cls = CollieDatasetForClassification(eval_dataset_cls, 
+                                              tokenizer=AutoTokenizer.from_pretrained("THUDM/chatglm2-6b", trust_remote_code=True, add_eos_token=True))
+### Prepare Evaluator
+evaluator_ppl = EvaluatorForPerplexity(
+    model=model,
+    config=config,
+    dataset=eval_dataset_ppl,
+    monitors=[
+        EvalMonitor(config)
+    ],
+    metrics={
+        "ppl": PPLMetric(gather_result=True)
+    },
+)
+evaluator_cls = EvaluatorForClassfication(
+    model=model,
+    config=config,
+    dataset=eval_dataset_cls,
+    monitors=[
+        EvalMonitor(config)
+    ],
+    metrics={
+        "acc": AccuracyMetric(gather_result=True)
+    },
+)
+### Prepare Trainer
+trainer = Trainer(
+    model=model,
+    lr_scheduler=lr_scheduler,
+    config=config,
+    optimizer=optimizer,
+    train_dataset=traine_dataset,
+    monitors=[
+        LossMonitor(config),
+        TGSMonitor(config),
+        MemoryMonitor(config),
+        LRMonitor(config)
+    ],
+    evaluators=evaluator_cls
+    # evaluators=[evaluator_ppl, evaluator_cls]
+)
+trainer.train()
+# trainer.save_checkpoint(path="/mnt/petrelfs/zhangshuo/model/test_save_checkpoint", mode="model")
+

--- a/tests/models/chatglm2/test_glm2_3d.py
+++ b/tests/models/chatglm2/test_glm2_3d.py
@@ -1,0 +1,26 @@
+import sys
+sys.path.append("../../../")
+
+from transformers import AutoTokenizer, GenerationConfig
+
+from collie.models import ChatGLM2ForCausalLM
+from collie import  CollieConfig, env
+
+tokenizer = AutoTokenizer.from_pretrained(
+        "THUDM/chatglm2-6b",
+        trust_remote_code=True,
+    )
+config = CollieConfig.from_pretrained("THUDM/chatglm2-6b",
+        trust_remote_code=True)
+config.tp_size = 2
+config.pp_size = 4
+model = ChatGLM2ForCausalLM.from_pretrained("THUDM/chatglm2-6b", config=config).cuda()
+prompt = "[Round 0]\n\n\n\n问：你是谁？\n\n答："
+inputs = tokenizer(prompt, return_tensors="pt")
+print(inputs)
+gen_config = GenerationConfig(max_new_tokens=256, early_stopping=True, eos_token_id=2)
+
+outs = model.generate(inputs["input_ids"].cuda(), generation_config=gen_config)
+if env.local_rank == 0:
+        print(outs)
+        print(tokenizer.decode(outs[0], skip_special_tokens=True))

--- a/tests/models/chatglm2/test_glm2_dp.py
+++ b/tests/models/chatglm2/test_glm2_dp.py
@@ -1,0 +1,26 @@
+import sys
+sys.path.append("../../../")
+
+from transformers import AutoTokenizer, GenerationConfig
+
+from collie.models import ChatGLM2ForCausalLM
+from collie import  CollieConfig, env
+
+tokenizer = AutoTokenizer.from_pretrained(
+        "THUDM/chatglm2-6b",
+        trust_remote_code=True,
+    )
+config = CollieConfig.from_pretrained("THUDM/chatglm2-6b",
+        trust_remote_code=True)
+config.dp_size = 8
+config.pp_size = 1
+model = ChatGLM2ForCausalLM.from_pretrained("THUDM/chatglm2-6b", config=config).cuda()
+prompt = "[Round 0]\n\n\n\n问：你是谁？\n\n答："
+inputs = tokenizer(prompt, return_tensors="pt")
+print(inputs)
+gen_config = GenerationConfig(max_new_tokens=256, early_stopping=True, eos_token_id=2)
+
+outs = model.generate(inputs["input_ids"].cuda(), generation_config=gen_config)
+if env.local_rank == 0:
+        print(outs)
+        print(tokenizer.decode(outs[0], skip_special_tokens=True))

--- a/tests/models/chatglm2/test_glm2_pp.py
+++ b/tests/models/chatglm2/test_glm2_pp.py
@@ -1,0 +1,26 @@
+import sys
+sys.path.append("../../../")
+
+from transformers import AutoTokenizer, GenerationConfig
+
+from collie.models import ChatGLM2ForCausalLM
+from collie import  CollieConfig, env
+
+tokenizer = AutoTokenizer.from_pretrained(
+        "THUDM/chatglm2-6b",
+        trust_remote_code=True,
+    )
+config = CollieConfig.from_pretrained("THUDM/chatglm2-6b",
+        trust_remote_code=True)
+config.dp_size = 1
+config.pp_size = 8
+model = ChatGLM2ForCausalLM.from_pretrained("THUDM/chatglm2-6b", config=config).cuda()
+prompt = "[Round 0]\n\n\n\n问：你是谁？\n\n答："
+inputs = tokenizer(prompt, return_tensors="pt")
+print(inputs)
+gen_config = GenerationConfig(max_new_tokens=256, early_stopping=True, eos_token_id=2)
+
+outs = model.generate(inputs["input_ids"].cuda(), generation_config=gen_config)
+if env.local_rank == 0:
+        print(outs)
+        print(tokenizer.decode(outs[0], skip_special_tokens=True))

--- a/tests/models/chatglm2/test_save_model.py
+++ b/tests/models/chatglm2/test_save_model.py
@@ -1,0 +1,22 @@
+import sys
+sys.path.append("../../../")
+
+from transformers import AutoTokenizer, GenerationConfig, AutoModel
+from collie.models import ChatGLM2ForCausalLM, LlamaForCausalLM
+from collie import  CollieConfig, env
+
+pretrained_path = "THUDM/chatglm2-6b"
+
+# tokenizer = AutoTokenizer.from_pretrained(
+#         pretrained_path,
+#         trust_remote_code=True,
+#     )
+config = CollieConfig.from_pretrained(pretrained_path,
+        trust_remote_code=True)
+config.tp_size = 1
+config.pp_size = 8
+model = ChatGLM2ForCausalLM.from_pretrained(pretrained_path, config=config).cuda()
+model.save_parallel_state_dict(model.state_dict(), "./dev", config=config)
+
+
+# model = AutoModel.from_pretrained("./dev", trust_remote_code=True)


### PR DESCRIPTION
1. 修改model中的chatglm2模型架构
2. 测试pp,dp,pp+tp的文本生成
3. 测试pp,dp,dp+tp的文本分类任务
4. 修改了accuracy的返回的dict中存在类型为numpy的bug