### PR TITLE
perf(monitor): add init mode for monitor

### DIFF
--- a/collie/utils/monitor.py
+++ b/collie/utils/monitor.py
@@ -219,7 +219,7 @@ class LRMonitor(BaseMonitor):
 class _MultiMonitors:
     def __init__(self, monitors: Sequence[BaseMonitor]) -> None:
         self.monitors = monitors
-        self.item = {}
+        self.item = {"mode": "init"}
     
     def __enter__(self):
         for monitor in self.monitors:


### PR DESCRIPTION
给monitor添加一个初始的mode，优化train_fn eval_fn报错的报错显示