### PR TITLE
fix(dataset): concat input&output then tokenize

### DIFF
--- a/collie/data/dataset.py
+++ b/collie/data/dataset.py
@@ -204,19 +204,27 @@ class CollieDatasetForTraining(Dataset):
                 )
                 outputs = self.tokenizer(
                     self.dataset[index]["output"],
-                    add_special_tokens=False,
+                    add_special_tokens=self.add_special_tokens,
                 )
-                inputs["input_ids"] += outputs["input_ids"]
-                inputs["attention_mask"] += outputs["attention_mask"]
+                target_length = len(
+                    outputs.input_ids
+                )
+                if self.add_special_tokens:
+                    if self.eos_length != 0:
+                        inputs["input_ids"] = inputs["input_ids"][:-self.eos_length]
+                        inputs["attention_mask"] = inputs["attention_mask"][:-self.eos_length]
+                    inputs["input_ids"] += outputs["input_ids"][self.bos_length:]
+                    inputs["attention_mask"] += outputs["attention_mask"][self.bos_length:]
+                    target_length -= self.bos_length
+                else:
+                    inputs["input_ids"] += outputs["input_ids"]
+                    inputs["attention_mask"] += outputs["attention_mask"]
                 input_ids = inputs["input_ids"]
                 attention_mask = inputs.get(
                     "attention_mask",
                     [1 for _ in range(len(input_ids))],
                 )
                 labels = torch.tensor(input_ids)
-                target_length = len(
-                    outputs.input_ids
-                )
                 labels[: -target_length] = -100
                 labels = labels.cpu().tolist()
             else:
@@ -483,10 +491,21 @@ class CollieDatasetForClassification(CollieDatasetForTraining):
                         )
                         outputs = self.tokenizer(
                             output,
-                            add_special_tokens=False,
+                            add_special_tokens=self.add_special_tokens,
                         )
-                        inputs["input_ids"] += outputs["input_ids"]
-                        inputs["attention_mask"] += outputs["attention_mask"]
+                        target_length = len(
+                            outputs.input_ids
+                        )
+                        if self.add_special_tokens:
+                            if self.eos_length != 0:
+                                inputs["input_ids"] = inputs["input_ids"][:-self.eos_length]
+                                inputs["attention_mask"] = inputs["attention_mask"][:-self.eos_length]
+                            inputs["input_ids"] += outputs["input_ids"][self.bos_length:]
+                            inputs["attention_mask"] += outputs["attention_mask"][self.bos_length:]
+                            target_length -= self.bos_length
+                        else:
+                            inputs["input_ids"] += outputs["input_ids"]
+                            inputs["attention_mask"] += outputs["attention_mask"]
                         input_ids.append(inputs.get("input_ids"))
                         attention_mask.append(
                             inputs.get(
@@ -495,9 +514,7 @@ class CollieDatasetForClassification(CollieDatasetForTraining):
                             )
                         )
                         label = torch.tensor(inputs.get("input_ids"))
-                        target_length = len(
-                            outputs.input_ids
-                        )
+                            
                         label[: -target_length] = -100
                         label = label.cpu().tolist()
                         labels.append(label)

--- a/collie/data/dataset.py
+++ b/collie/data/dataset.py
@@ -476,7 +476,7 @@ class CollieDatasetForClassification(CollieDatasetForTraining):
                     input_ids = []
                     attention_mask = []
                     labels = []
-                    for output in self.dataset[index]["output"]:           
+                    for output in self.dataset[index]["output"]:
                         inputs = self.tokenizer(
                             self.dataset[index]["input"],
                             add_special_tokens=self.add_special_tokens,

--- a/collie/data/dataset.py
+++ b/collie/data/dataset.py
@@ -7,7 +7,7 @@ import os
 import random
 import threading
 from functools import reduce
-from typing import Dict, List, Optional, Sequence, Tuple, Callable
+from typing import Dict, List, Optional, Sequence, Tuple, Callable, Union
 
 import numpy as np
 import torch
@@ -163,7 +163,7 @@ class CollieDatasetForTraining(Dataset):
     def __len__(self):
         return len(self.dataset)
 
-    def __getitem__(self, index) -> Dict or List[Dict]:
+    def __getitem__(self, index) -> Union[Dict, List[Dict]]:
         if isinstance(index, slice):
             return self._get_slice(index)
         if index > len(self):
@@ -199,9 +199,15 @@ class CollieDatasetForTraining(Dataset):
                     "input" in self.dataset[0].keys() and "output" in self.dataset[0].keys()
             ):
                 inputs = self.tokenizer(
-                    self.dataset[index]["input"] + self.dataset[index]["output"],
+                    self.dataset[index]["input"],
                     add_special_tokens=self.add_special_tokens,
                 )
+                outputs = self.tokenizer(
+                    self.dataset[index]["output"],
+                    add_special_tokens=False,
+                )
+                inputs["input_ids"] += outputs["input_ids"]
+                inputs["attention_mask"] += outputs["attention_mask"]
                 input_ids = inputs["input_ids"]
                 attention_mask = inputs.get(
                     "attention_mask",
@@ -209,13 +215,8 @@ class CollieDatasetForTraining(Dataset):
                 )
                 labels = torch.tensor(input_ids)
                 target_length = len(
-                    self.tokenizer(
-                        self.dataset[index]["output"],
-                        add_special_tokens=self.add_special_tokens,
-                    ).input_ids
+                    outputs.input_ids
                 )
-                if self.add_special_tokens:
-                    target_length -= self.bos_length
                 labels[: -target_length] = -100
                 labels = labels.cpu().tolist()
             else:
@@ -475,11 +476,17 @@ class CollieDatasetForClassification(CollieDatasetForTraining):
                     input_ids = []
                     attention_mask = []
                     labels = []
-                    for output in self.dataset[index]["output"]:
+                    for output in self.dataset[index]["output"]:           
                         inputs = self.tokenizer(
-                            self.dataset[index]["input"] + output,
+                            self.dataset[index]["input"],
                             add_special_tokens=self.add_special_tokens,
                         )
+                        outputs = self.tokenizer(
+                            output,
+                            add_special_tokens=False,
+                        )
+                        inputs["input_ids"] += outputs["input_ids"]
+                        inputs["attention_mask"] += outputs["attention_mask"]
                         input_ids.append(inputs.get("input_ids"))
                         attention_mask.append(
                             inputs.get(
@@ -489,13 +496,8 @@ class CollieDatasetForClassification(CollieDatasetForTraining):
                         )
                         label = torch.tensor(inputs.get("input_ids"))
                         target_length = len(
-                            self.tokenizer(
-                                output,
-                                add_special_tokens=self.add_special_tokens,
-                            ).input_ids
+                            outputs.input_ids
                         )
-                        if self.add_special_tokens:
-                            target_length -= self.bos_length
                         label[: -target_length] = -100
                         label = label.cpu().tolist()
                         labels.append(label)

--- a/collie/data/template_utils.py
+++ b/collie/data/template_utils.py
@@ -1,5 +1,5 @@
 import json
-from typing import Callable
+from typing import Callable, Optional, Union
 
 
 def prepare_chatml_messages(messages, special_tokens_map, text_field, add_generation_prompt=False):
@@ -129,7 +129,7 @@ TOKENIZER_PREPARE_TEMPLATE_FN_MAPPING = {
 }
 
 
-def tokenize_conversation(conversation, tokenizer, text_field='history', prepare_template_fn: Callable or None = None,
+def tokenize_conversation(conversation, tokenizer, text_field='history', prepare_template_fn: Optional[Callable] = None,
                           add_generation_prompt=False):
     if prepare_template_fn is None:
         if type(tokenizer).__name__ not in TOKENIZER_PREPARE_TEMPLATE_FN_MAPPING:
@@ -224,7 +224,7 @@ if __name__ == "__main__":
     T['history'] = [t for t in T['chat'] if "content" in t]
 
 
-    def _colored_string(string: str, color: str or int) -> str:
+    def _colored_string(string: str, color: Union[str, int]) -> str:
         """在终端中显示一串有颜色的文字
 
         :param string: 在终端中显示的文字


### PR DESCRIPTION
在一些dataset上，tokenizer会将input与output拼接后再统一tokenize，可能导致错误

例：
使用internlm2词表。此处会把input的最后一个token与output的第一个token拼起来

```
train_dataset = [
    {
        "input": "The sentiment of this comment is: ",
        "output": "negative.",
    }
]

train_dataset_classification = [
    {
        "input": "The sentiment of this comment is: ",
        "output": ["negative.", "positive."],
        "target": 0,
    }
]

train_dataset = CollieDatasetForTraining(train_dataset, tokenizer)
print(train_dataset[0])
# {'input_ids': [1, 918, 26413, 446, 550, 4137, 505, 334, 8357, 281], 'attention_mask': [1, 1, 1, 1, 1, 1, 1, 1, 1, 1], 'labels': [-100, -100, -100, -100, -100, -100, -100, -100, 8357, 281]}
# 修改后
# {'input_ids': [1, 918, 26413, 446, 550, 4137, 505, 334, 262, 41889, 281], 'attention_mask': [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], 'labels': [-100, -100, -100, -100, -100, -100, -100, -100, -100, 41889, 281]}
train_dataset_classification = CollieDatasetForClassification(train_dataset_classification, tokenizer)
print(train_dataset_classification[0])
# {'input_ids': ([1, 918, 26413, 446, 550, 4137, 505, 334, 8357, 281], [1, 918, 26413, 446, 550, 4137, 505, 334, 6936, 281]), 'attention_mask': ([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]), 'labels': ([-100, -100, -100, -100, -100, -100, -100, -100, 8357, 281], [-100, -100, -100, -100, -100, -100, -100, -100, 6936, 281]), 'target': 0}
# 修改后
# {'input_ids': ([1, 918, 26413, 446, 550, 4137, 505, 334, 262, 41889, 281], [1, 918, 26413, 446, 550, 4137, 505, 334, 262, 30721, 281]), 'attention_mask': ([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]), 'labels': ([-100, -100, -100, -100, -100, -100, -100, -100, -100, 41889, 281], [-100, -100, -100, -100, -100, -100, -100, -100, -100, 30721, 281]), 'target': 0}

print(tokenizer.encode("The sentiment of this comment is: "))
# [1, 918, 26413, 446, 550, 4137, 505, 334, 262]
print(tokenizer.encode("negative.", add_special_tokens=False))
# [41889, 281]
```
